### PR TITLE
fix login alert translation

### DIFF
--- a/config/locales/en.flash.yml
+++ b/config/locales/en.flash.yml
@@ -1,0 +1,22 @@
+en:
+  flash:
+    web:
+      languages:
+        lessons:
+          show:
+            lesson_not_found: Lesson not found. Please, start other lessons.
+      users:
+        create:
+          success: You have successfully signed in. You can start learning now.
+      sessions:
+        create:
+          success: You have successfully signed in. You can start learning now.
+      auth:
+        callback:
+          success: You have successfully signed in. You can start learning now.
+      remind_passwords:
+        create:
+          success: We have sent you password recovery instructions to your mailbox.
+      passwords:
+        update:
+          success: Password has been changed. Please login with a new password.


### PR DESCRIPTION
Fix for login and sign-up alerts translations (English version). 
Current experience: 
![image](https://user-images.githubusercontent.com/55243777/104816012-61a46800-5829-11eb-9ea6-ca1ec4ff4552.png)

Improved:
![image](https://user-images.githubusercontent.com/55243777/104816024-7da80980-5829-11eb-9b7d-27fddb06dc50.png)
