### PR TITLE
add go syntax highlighting in editor[iss-121]

### DIFF
--- a/app/javascript/packs/lesson/components/Editor.jsx
+++ b/app/javascript/packs/lesson/components/Editor.jsx
@@ -21,6 +21,7 @@ import 'codemirror/mode/php/php.js';
 import 'codemirror/mode/sass/sass.js';
 import 'codemirror/mode/pug/pug.js';
 import 'codemirror/mode/clike/clike.js';
+import 'codemirror/mode/go/go';
 
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/addon/scroll/simplescrollbars.css';


### PR DESCRIPTION
Editor before: 
![GO_Before](https://user-images.githubusercontent.com/55243777/105042892-d835a580-5a75-11eb-837f-a00d65438f67.png)

Editor after:
![GO_After](https://user-images.githubusercontent.com/55243777/105042910-e1267700-5a75-11eb-92c0-e8a301ae000a.png)
