### PR TITLE
fix submit button names in registration forms (russian and english)

### DIFF
--- a/app/views/web/users/new.html.slim
+++ b/app/views/web/users/new.html.slim
@@ -17,7 +17,7 @@
           = f.input :email
           = f.input :password
           .form-group.mt-5
-            = f.submit t('.sign_up'), class: 'btn btn-primary mb-2 btn-block'
+            = f.submit class: 'btn btn-primary mb-2 btn-block'
             = link_to auth_request_path('github'), method: :post, class: 'btn btn-secondary btn-block' do
               span.fab.mr-2.fa-github
               = t('.sign_up_with_github')

--- a/app/views/web/users/new.html.slim
+++ b/app/views/web/users/new.html.slim
@@ -17,7 +17,7 @@
           = f.input :email
           = f.input :password
           .form-group.mt-5
-            = f.submit class: 'btn btn-primary mb-2 btn-block'
+            = f.submit t('.sign_up'), class: 'btn btn-primary mb-2 btn-block'
             = link_to auth_request_path('github'), method: :post, class: 'btn btn-secondary btn-block' do
               span.fab.mr-2.fa-github
               = t('.sign_up_with_github')

--- a/config/locales/en.helpers.yml
+++ b/config/locales/en.helpers.yml
@@ -5,5 +5,5 @@ en:
       update: Update
       sign_in:
         create: Sign in
-      user:
+      user_sign_up_form:
         create: Sign up

--- a/config/locales/ru.helpers.yml
+++ b/config/locales/ru.helpers.yml
@@ -5,6 +5,6 @@ ru:
       update: Изменить
       sign_in:
         create: Войти
-      user:
-        create: Зарегистрироваться
+      user_sign_up_form:
+        create: Регистрация
 


### PR DESCRIPTION
Fix submit buttons' names for russian and english versions. 

Before: 
![RU_Register](https://user-images.githubusercontent.com/55243777/105579299-bfd7ca80-5d96-11eb-9396-e34bdef5d295.png)
![EN_register](https://user-images.githubusercontent.com/55243777/105579304-c2d2bb00-5d96-11eb-85b6-e87d1ec74717.png)

After: 
![RU_after_register](https://user-images.githubusercontent.com/55243777/105579331-f44b8680-5d96-11eb-8218-dd9c0350cb32.png)
![EN_after_register](https://user-images.githubusercontent.com/55243777/105579333-f6154a00-5d96-11eb-958d-665a7173e900.png)
