### PR TITLE
fix forgot password button's translations(ru & en)

### DIFF
--- a/config/locales/en.helpers.yml
+++ b/config/locales/en.helpers.yml
@@ -7,3 +7,5 @@ en:
         create: Sign in
       user_sign_up_form:
         create: Sign up
+      remind_password:
+        create: Reset password

--- a/config/locales/ru.helpers.yml
+++ b/config/locales/ru.helpers.yml
@@ -7,4 +7,6 @@ ru:
         create: Войти
       user_sign_up_form:
         create: Регистрация
+      remind_password:
+        create: Восстановить пароль
 


### PR DESCRIPTION
This is a fox for button's translations. 

Before: 
![forgot_password_RU](https://user-images.githubusercontent.com/55243777/105642134-f0079200-5e98-11eb-8440-88ef59d92450.png)
![forgot_password_EN](https://user-images.githubusercontent.com/55243777/105642135-f3028280-5e98-11eb-9d14-38eb18735c74.png)

After: 
![after_forgot_password_RU](https://user-images.githubusercontent.com/55243777/105642141-f8f86380-5e98-11eb-8858-3587086db51a.png)
![after_forgot_password_EN](https://user-images.githubusercontent.com/55243777/105642145-fc8bea80-5e98-11eb-905b-dc6cafc67f1e.png)
