### PR TITLE
fix 'courses in development' section translation

### DIFF
--- a/config/locales/en.views.yml
+++ b/config/locales/en.views.yml
@@ -19,6 +19,8 @@ en:
         subheader: "For those who start from scratch. From the creators of "
         start: "Start"
         hexlet: "Hexlet"
+        in_development: Coming soon
+        in_development_description: Courses below are not in production at the moment. However, you can contribute by sending a pull request to Github repository.
       languages:
         start: Start
         continue: Continue


### PR DESCRIPTION
this will fix translation 'courses in development'.

Screenshot below: 
![image](https://user-images.githubusercontent.com/55243777/106664897-b6303d00-65b6-11eb-9b7a-a79d7463d3ab.png)
