### PR TITLE
fix syntax highlighting for editor

### DIFF
--- a/app/javascript/packs/lesson/components/Editor.jsx
+++ b/app/javascript/packs/lesson/components/Editor.jsx
@@ -3,7 +3,8 @@ import { useSelector, useDispatch } from 'react-redux';
 import { UnControlled as CodeMirrorEditor } from 'react-codemirror2';
 import { useLocalStorage } from '@rehooks/local-storage';
 import { actions } from '../slices/index.js';
-import { getLanguage, getTabSize } from '../utils/editorUtils.js';
+import { getLanguageForEditor, getTabSize } from '../utils/editorUtils.js';
+
 import EntityContext from '../EntityContext.js';
 
 import 'codemirror/mode/htmlmixed/htmlmixed.js';
@@ -95,7 +96,7 @@ const Editor = () => {
 
   const options = {
     ...commonOptions,
-    mode: getLanguage(language),
+    mode: getLanguageForEditor(language),
     indentUnit: getTabSize(language),
     extraKeys: {
       Tab: replaceTab,

--- a/app/javascript/packs/lesson/utils/editorUtils.js
+++ b/app/javascript/packs/lesson/utils/editorUtils.js
@@ -6,6 +6,13 @@ const languageMapping = {
   html: 'text/html',
 };
 
+const editorMapping = {
+  racket: 'scheme',
+  html: 'text/html',
+  css: 'text/html',
+  java: 'text/x-java',
+};
+
 const langToTabSizeMapping = {
   javascript: 2,
   ruby: 2,
@@ -14,10 +21,13 @@ const langToTabSizeMapping = {
   elixir: 2,
   html: 2,
   python: 4,
+  java: 4,
 };
 
 const defaultTabSize = 4;
 
 export const getLanguage = (language) => _.get(languageMapping, language, language);
+
+export const getLanguageForEditor = (language) => _.get(editorMapping, language, language);
 
 export const getTabSize = (language) => _.get(langToTabSizeMapping, language, defaultTabSize);


### PR DESCRIPTION
Там в джаве и в сss не работал syntax highligh для editor