### PR TITLE
small fix for 404 issue in ruby modules

### DIFF
--- a/app/helpers/lesson_helper.rb
+++ b/app/helpers/lesson_helper.rb
@@ -31,6 +31,6 @@ module LessonHelper
     locale = lesson_version_info.locale
     path_to_description = File.join(repository_path, lesson_version.path_to_code, "description.#{locale}.yml")
 
-    path_to_description.gsub('modules', 'blob/master/modules')
+    path_to_description.sub('modules', 'blob/master/modules')
   end
 end


### PR DESCRIPTION
Там была не большая проблема в что в уроке https://ru.code-basics.com/languages/ruby/lessons/modules . Когда мы кликали на "Нашли ошибку" , которая перекидывала на github. Он генерил не правильный url 

* Был такой `https://github.com/hexlet-basics/exercises-ruby/blob/master/modules/10-basics/65-blob/master/modules/description.ru.yml`
* Стал такой `https://github.com/hexlet-basics/exercises-ruby/blob/master/modules/10-basics/65-modules/description.ru.yml`