### PR TITLE
codemirror bugfix

### DIFF
--- a/app/packs/src/lesson/components/Editor.jsx
+++ b/app/packs/src/lesson/components/Editor.jsx
@@ -74,7 +74,8 @@ const Editor = () => {
     self.focus();
     self.refresh();
     if (localStorageContent) {
-      self.getDoc().setValue(localStorageContent);
+      const stringifiedContent = JSON.stringify(localStorageContent);
+      self.getDoc().setValue(stringifiedContent);
     }
   };
 


### PR DESCRIPTION
Сейчас, если записать в редакторе не строку (число, объект или булево true), то при следующем обращении к решению из локального хранилища в редактор попадёт не строка. Кодмиррор упадёт с ошибкой, так как не сможет сделать сплит контента по строчкам. Пользователь не сможет больше получить доступ к редактору, пока вручную не удалит из хранилища данное значение.

Предлагаю перед тем, как скармливать контент в редактор, преобразовать содержимое локального хранилища в строку.