### PR TITLE
Ctrl-Enter Editor fix

### DIFF
--- a/app/packs/src/lesson/components/Editor.jsx
+++ b/app/packs/src/lesson/components/Editor.jsx
@@ -92,7 +92,6 @@ const Editor = () => {
   const handleRunCheck = (e) => {
     const value = e.getValue();
     dispatch(actions.runCheck({ lessonVersion, editor: { content: value } }));
-    debugger;
   };
 
   const options = {

--- a/app/packs/src/lesson/components/Editor.jsx
+++ b/app/packs/src/lesson/components/Editor.jsx
@@ -89,6 +89,12 @@ const Editor = () => {
     cm.replaceSelection(spaces);
   };
 
+  const handleRunCheck = (e) => {
+    const value = e.getValue();
+    dispatch(actions.runCheck({ lessonVersion, editor: { content: value } }));
+    debugger;
+  };
+
   const options = {
     autofocus: true,
     ...commonOptions,
@@ -96,9 +102,7 @@ const Editor = () => {
     indentUnit: getTabSize(language),
     extraKeys: {
       Tab: replaceTab,
-      'Ctrl-Enter': () => {
-        dispatch(actions.runCheck({ lessonVersion, editor: content }));
-      },
+      'Ctrl-Enter': handleRunCheck,
     },
   };
 


### PR DESCRIPTION
#174 Теперь контент корректно попадает в runCheck. Проверил на js, python, css

![Снимок экрана от 2021-07-09 13-31-53](https://user-images.githubusercontent.com/69354716/125034678-102fb400-e0bb-11eb-9f76-2a64debeea07.png)
