### PR TITLE
fix language hero devicon

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,6 +106,15 @@ module ApplicationHelper
     mapping.fetch(slug, 'hexlet_logo.png')
   end
 
+  def get_language_devicon_name(slug)
+    mapping = {
+      'html' => 'html5',
+      'css' => 'css3'
+    }
+
+    mapping.fetch(slug, slug)
+  end
+
   def get_continue_study_path(slug)
     mapping = {
       'php' => ExternalLinks.hexlet_php,

--- a/app/views/web/languages/show.html.slim
+++ b/app/views/web/languages/show.html.slim
@@ -39,7 +39,7 @@
         .d-none.d-md-block.col-4.align-self-center.text-center
           / FIXME нужно добыть картинки
           / = image_pack_tag("#{@language.slug}_512x512.png", class: 'img-fluid', width: 512, height: 512, alt: @language, itemprop: 'contentUrl') rescue nil
-          span.colored.x-fs-15 class="devicon-#{@language.slug}-plain"
+          span.colored.x-fs-15 class="devicon-#{get_language_devicon_name(@language.slug)}-plain"
 
     .
       - if @language_member.finished?


### PR DESCRIPTION
fix #235 
[html5](https://user-images.githubusercontent.com/697178/138891309-de1b6088-8821-4cec-98e0-85d5545921d3.png)
[css3](https://user-images.githubusercontent.com/697178/138891353-c3c8007d-1475-4083-bc5b-2afd41f72382.png)
[php для примера, где работало](https://user-images.githubusercontent.com/697178/138891393-a8d720b3-3523-498e-a510-8d56552b130f.png)

Вопрос - в навигации тоже стоит заюзать хелпер для получения имени для иконки? Стоит делать как щас или имеет смысл сразу возвращать имя класса из хелпера типа `devicon-php-plain`?