### PR TITLE
add html markup definition for CSS course

### DIFF
--- a/app/packs/src/lesson/utils/editorUtils.js
+++ b/app/packs/src/lesson/utils/editorUtils.js
@@ -8,6 +8,7 @@ const languageMapping = {
 };
 
 const editorMapping = {
+  css: 'html',
   racket: 'scheme',
   clang: 'c',
   bash: 'shell',


### PR DESCRIPTION
Переопределил настройки редактора, так как в курсе CSS мы, по сути, работаем внутри HTML файла