### PR TITLE
fix: set href in "a" tag if lesson is finished #276

### DIFF
--- a/app/javascript/lesson/components/ControlBox.jsx
+++ b/app/javascript/lesson/components/ControlBox.jsx
@@ -72,7 +72,7 @@ function ControlBox() {
     disabled: !lessonInfo.finished,
   });
 
-  const nextLessonPath = routes.nextLessonLanguageLessonPath(language, lesson.slug);
+  const nextLessonPath = lessonInfo.finished ? routes.nextLessonLanguageLessonPath(language, lesson.slug) : null;
   const prevLessonPath = routes.prevLessonLanguageLessonPath(language, lesson.slug);
 
   useHotkeys('ctrl+enter', handleRunCheck);


### PR DESCRIPTION
Решение в лоб, но по проекту только в одном месте (насколько я нашел) используется тег `a` с классом `disabled`. Задизейблить ссылку нельзя атрибутом `disabled` для навигации через tab, но можно не использовать href в теге