### PR TITLE
Fix tooltip visibility while going outside borders

### DIFF
--- a/app/javascript/lesson/components/Editor.jsx
+++ b/app/javascript/lesson/components/Editor.jsx
@@ -22,6 +22,7 @@ const commonOptions = {
   renderWhitespace: 'trailing',
   formatOnPaste: true,
   renderLineHighlight: false,
+  fixedOverflowWidgets: true,
 };
 
 function Editor() {


### PR DESCRIPTION
Проходя курс по TS заметил один баг
Сейчас подсказки при выходе за рамки обрезаются и чтобы что-то увидеть надо двигать код вниз
![image](https://user-images.githubusercontent.com/101341358/209451282-f8e5d808-f6e5-41bc-880e-a6e9b18995be.png)

Нашел [настройку](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IDiffEditorConstructionOptions.html#fixedOverflowWidgets) для редактора, с ней все отлично
![image](https://user-images.githubusercontent.com/101341358/209451345-f4ef6be7-2e6d-4da7-9337-18f1ed7ddee4.png)

