### PR TITLE
add autocomplete attribute to email and password fields

### DIFF
--- a/app/views/web/home/index.html.slim
+++ b/app/views/web/home/index.html.slim
@@ -44,8 +44,8 @@
             .card-body
               = simple_form_for @user, url: users_path do |f|
                 = f.input :first_name
-                = f.input :email
-                = f.input :password
+                = f.input :email, input_html: { autocomplete: 'email' }
+                = f.input :password, input_html: { autocomplete: 'new-password' }
                 .form-group
                   = f.submit class: 'btn btn-primary w-100'
                 = render 'web/shared/via_social_networks'

--- a/app/views/web/passwords/edit.html.slim
+++ b/app/views/web/passwords/edit.html.slim
@@ -17,5 +17,5 @@
         .card-body.p-4.p-lg-5
           h1.h3.mb-4.text-center = t('.new_password')
           = simple_form_for @user, url: password_path(reset_password_token: params[:reset_password_token]), wrapper: :floating_labels_form do |f|
-            = f.input :password
+            = f.input :password, input_html: { autocomplete: 'new-password' }
             = f.submit class: 'btn btn-lg btn-primary w-100'

--- a/app/views/web/sessions/new.html.slim
+++ b/app/views/web/sessions/new.html.slim
@@ -19,8 +19,8 @@
       .card.shadow-sm.border-0
         .card-body.m-4
           = simple_form_for @sign_in_form, url: session_path do |f|
-            = f.input :email, input_html: { 'data-testid' => 'email' }
-            = f.input :password, input_html: { 'data-testid' => 'password' }
+            = f.input :email, input_html: { 'data-testid' => 'email', autocomplete: 'email' }
+            = f.input :password, input_html: { 'data-testid' => 'password', autocomplete: 'current-password' }
             .text-end.small.my-4
               = link_to t('.forgot_password'), new_remind_password_path, class: 'text-decoration-none'
             .form-group

--- a/app/views/web/users/new.html.slim
+++ b/app/views/web/users/new.html.slim
@@ -20,8 +20,8 @@
         .card-body.m-4
           = simple_form_for @user, url: users_path do |f|
             = f.input :first_name
-            = f.input :email
-            = f.input :password
+            = f.input :email, input_html: { autocomplete: 'email' }
+            = f.input :password, input_html: { autocomplete: 'new-password' }
             .text-end.text-muted.small.my-4
               span.me-2 = t('.have_account')
               = link_to t('.sign_in'), new_session_path, class: 'text-decoration-none'


### PR DESCRIPTION
<img width="851" alt="image" src="https://user-images.githubusercontent.com/29174482/220659253-fd5a2a2f-6d03-4f21-bdd9-ff59087881ce.png">

Рекомендации, на основе которых он ругается — https://www.chromium.org/developers/design-documents/create-amazing-password-forms/