### PR TITLE
makefiles to compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Requirements
 
 * docker
-* docker compose
+* docker compose V2
 * ruby >= 3.0.0
 * make
 

--- a/make-compose-app.mk
+++ b/make-compose-app.mk
@@ -1,31 +1,31 @@
 app-bash:
-	docker-compose run --rm web /bin/bash
+	docker compose run --rm web /bin/bash
 
 app-language-load:
-	docker-compose run --rm web make language-load L=${L}
+	docker compose run --rm web make language-load L=${L}
 
 app-lint:
-	docker-compose run --rm --no-deps web make lint
+	docker compose run --rm --no-deps web make lint
 
 app-lint-fix:
-	docker-compose run --rm --no-deps web make lint-fix
+	docker compose run --rm --no-deps web make lint-fix
 
 app-test:
-	docker-compose run --rm web make test
+	docker compose run --rm web make test
 
 app-check: app-test app-lint
 
 app-test-file:
-	docker-compose run --rm web make test-file T=${T}
+	docker compose run --rm web make test-file T=${T}
 
 app-rails-console:
-	docker-compose run --rm web bin/rails c
+	docker compose run --rm web bin/rails c
 
 app-setup-git-hooks:
-	docker-compose run --rm web npx simple-git-hooks
+	docker compose run --rm web npx simple-git-hooks
 
 app-lint-staged:
-	docker-compose run -T --rm web npx lint-staged --relative
+	docker compose run -T --rm web npx lint-staged --relative
 
 app-languages-load:
 	make app-language-load L='javascript'
@@ -62,7 +62,7 @@ app-languages-load:
 app-setup: app-install app-db-prepare app-setup-git-hooks app-languages-load
 
 app-install:
-	docker-compose run --rm web make setup
+	docker compose run --rm web make setup
 
 app-db-prepare:
-	docker-compose run --rm web make db-prepare
+	docker compose run --rm web make db-prepare

--- a/make-compose.mk
+++ b/make-compose.mk
@@ -1,33 +1,33 @@
 compose:
-	docker-compose up -d
+	docker compose up -d
 
 compose-production:
-	docker-compose --file docker-compose.yml run production
+	docker compose --file docker-compose.yml run production
 
 compose-build:
-	docker-compose build
+	docker compose build
 
 compose-logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 compose-down:
-	docker-compose down --remove-orphans || true
+	docker compose down --remove-orphans || true
 
 compose-clear:
-	docker-compose down -v --remove-orphans || true
+	docker compose down -v --remove-orphans || true
 
 compose-stop:
-	docker-compose stop || true
+	docker compose stop || true
 
 compose-restart:
-	docker-compose restart
+	docker compose restart
 
 compose-setup: compose-down compose-build app-setup
 
 compose-ci-build:
 	docker build -f Dockerfile.production -t hexletbasics/services-app .
 	docker build -f services/web-nginx/Dockerfile -t hexletbasics/services-web .
-	docker-compose -f docker-compose.yml build
+	docker compose -f docker-compose.yml build
 
 compose-ci: compose-ci-build
-	docker-compose --file docker-compose.yml up --abort-on-container-exit
+	docker compose --file docker-compose.yml up --abort-on-container-exit


### PR DESCRIPTION
Смена команды `docker-compose` на `docker compose` в связи с https://docs.docker.com/compose/migrate/. С `docker-compose` проект не устанавливается и не запускается.