### PR TITLE
fix encoding for exercise checking output

### DIFF
--- a/app/javascript/lesson/components/Output.jsx
+++ b/app/javascript/lesson/components/Output.jsx
@@ -27,6 +27,8 @@ function Output() {
     'alert-success': checkInfo.passed,
     'alert-warning': !checkInfo.passed,
   });
+  // NOTE: исправление неверной кодировки для кириллицы
+  // https://developer.mozilla.org/en-US/docs/Glossary/Base64
   const output = ansi.ansi_to_html(decodeURIComponent(escape(checkInfo.output)));
 
   return (

--- a/app/javascript/lesson/components/Output.jsx
+++ b/app/javascript/lesson/components/Output.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import cn from 'classnames';
 import AnsiUp from 'ansi_up';
 
+import escape from 'core-js/actual/escape.js';
 import { checkInfoStates } from '../utils/maps.js';
 import EntityContext from '../EntityContext.js';
 
@@ -26,10 +27,12 @@ function Output() {
     'alert-success': checkInfo.passed,
     'alert-warning': !checkInfo.passed,
   });
+  const output = ansi.ansi_to_html(decodeURIComponent(escape(checkInfo.output)));
+
   return (
     <div className="d-flex flex-column h-100">
       <pre>
-        <code className="nohighlight" dangerouslySetInnerHTML={{ __html: ansi.ansi_to_html(checkInfo.output) }} />
+        <code className="nohighlight" dangerouslySetInnerHTML={{ __html: output }} />
       </pre>
       <div className={alertClassName} dangerouslySetInnerHTML={{ __html: message }} />
       {!lessonMember.id && checkInfo.passed && (


### PR DESCRIPTION
задача - https://www.notion.so/hexlet-ru/output-code-basics-2c6d1dce5e834f4cab167c1c9211a20e
проблема: кириллица в выводе тестов отображается некорректно
Поправил.
Результат:
![2023-06-10_18-19-49](https://github.com/hexlet-basics/hexlet-basics/assets/12639352/93359beb-614b-4836-b04e-bcfb774f455b)
