### PR TITLE
do not send to sentry error with scroll regions because of actual issue

### DIFF
--- a/app/javascript/entrypoints/inertia.tsx
+++ b/app/javascript/entrypoints/inertia.tsx
@@ -17,6 +17,10 @@ type ResolvedComponent = {
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
+  ignoreErrors: [
+    // https://github.com/inertiajs/inertia/issues/2204
+    "Cannot read properties of null (reading 'scrollRegions')",
+  ],
 });
 
 createInertiaApp({


### PR DESCRIPTION
Ишью актуальный, плюс есть ещё несколько
Предлагаю пока не слать ошибки в сентри так как можем выйти за лимит событий в аккаунте
Сейчас в день приходит коло 2500 ошибок