### PR TITLE
add solution_checked event

### DIFF
--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -51,6 +51,15 @@ class Api::LessonsController < Api::ApplicationController
       end
     end
 
+    event_data = {
+      lesson_slug: lesson.slug,
+      course_slug: language.slug,
+      locale: language_info.locale,
+      passed: lesson_exercise_data[:passed]
+    }
+    event = SolutionCheckedEvent.new(data: event_data)
+    publish_event(event, current_user)
+
     response_data = OpenStruct.new({
       **lesson_exercise_data,
       lesson_has_been_finished:,

--- a/app/controllers/concerns/event_concern.rb
+++ b/app/controllers/concerns/event_concern.rb
@@ -34,6 +34,11 @@ module EventConcern
   end
 
   def publish_event(event, user)
+    if user.guest?
+      event_store.publish(event)
+      return
+    end
+
     event_store.publish(event, stream_name: "user-#{user.id}")
   end
 

--- a/app/events/SolutionCheckedEvent.rb
+++ b/app/events/SolutionCheckedEvent.rb
@@ -1,0 +1,2 @@
+class SolutionCheckedEvent < RailsEventStore::Event
+end

--- a/app/javascript/pages/web/languages/lessons/show/slices/RootSlice.ts
+++ b/app/javascript/pages/web/languages/lessons/show/slices/RootSlice.ts
@@ -30,10 +30,19 @@ export const runCheck = createAsyncThunk(
       },
     });
 
+    const response_data = response.data;
+
     const {
       lesson_has_been_finished: lessonHasBeenFinished,
       language_has_been_finished: courseHasBeenFinished,
     } = response.data;
+
+    analytics.track("solution_checked", {
+      course_slug: course.slug,
+      lesson_slug: lesson.slug,
+      passed: response_data.passed,
+      locale: lesson.locale,
+    });
 
     if (lessonHasBeenFinished) {
       analytics.track("lesson_finished", {
@@ -51,8 +60,8 @@ export const runCheck = createAsyncThunk(
     }
 
     const result = {
-      ...response.data,
-      output: atob(response.data.output),
+      ...response_data,
+      output: atob(response_data.output),
     };
     return result;
   },


### PR DESCRIPTION
Добавил событие проверки решения. Нужно для двух случаев:
1. Чтобы понимать в каком курсе и уроке пользователи допускают много ошибок
2. Отслеживать всех людей, которые проходят уроки. Так мы сможем понять, например, сколько пользователей проходят урок и потом регаются
3. Построить отчеты Dau/mau и тд, тк активный пользователь -- кто проходит уроки, но не обязательно это правильные решения