### PR TITLE
Handle errors with unknown format

### DIFF
--- a/app/controllers/concerns/locale_concern.rb
+++ b/app/controllers/concerns/locale_concern.rb
@@ -37,4 +37,19 @@ module LocaleConcern
       session[:locale] = I18n.locale
     end
   end
+
+  def locale_from_header
+    return unless request.env["HTTP_ACCEPT_LANGUAGE"]
+
+    # Extract the preferred locale from the Accept-Language header
+    parsed_locales = request.env["HTTP_ACCEPT_LANGUAGE"]
+                      .split(",")
+                      .map { |l| l.split(";").first }
+    # Find the first locale that is available in the app
+    parsed_locales.find { |locale| I18n.available_locales.map(&:to_s).include?(locale) }
+  end
+
+  def country_by_ip
+    @country_by_ip ||= Geocoder.search(request.remote_ip).first&.country_code || "EN"
+  end
 end

--- a/app/controllers/web/application_controller.rb
+++ b/app/controllers/web/application_controller.rb
@@ -66,19 +66,4 @@ class Web::ApplicationController < ApplicationController
   def redirect_to_inertia(url, model)
       redirect_to url, inertia: { errors: model.errors }
   end
-
-  def country_by_ip
-    @country_by_ip ||= Geocoder.search(request.remote_ip).first&.country_code || "EN"
-  end
-
-  def locale_from_header
-    return unless request.env["HTTP_ACCEPT_LANGUAGE"]
-
-    # Extract the preferred locale from the Accept-Language header
-    parsed_locales = request.env["HTTP_ACCEPT_LANGUAGE"]
-                      .split(",")
-                      .map { |l| l.split(";").first }
-    # Find the first locale that is available in the app
-    parsed_locales.find { |locale| I18n.available_locales.map(&:to_s).include?(locale) }
-  end
 end

--- a/app/controllers/web/errors_controller.rb
+++ b/app/controllers/web/errors_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class Web::ErrorsController < Web::ApplicationController
-  # NOTE: for 404 page locale from route params is undefined
-  around_action :use_locale # , only: :not_found
+  # NOTE: for error pages locale from route params is undefined
+  around_action :use_locale
+
+  before_action do
+    request.format = :html
+  end
 
   def show
     code = params[:code].to_i

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,8 @@ module HexletBasics
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     # config.middleware.use ActiveStorage::SetCurrent
+
+    config.i18n.available_locales = %i[en ru]
+    config.i18n.default_locale = :en
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
       end
     end
 
-    scope module: :web do
+    scope module: :web, format: false do
       root "home#index"
 
       get "/robots.:format" => "home#robots", as: :robots


### PR DESCRIPTION
Отключил использование форматов в запросах по дефолту. Где нужно мы и так описываем явно
Поправил отображение страницы ошибки, так как форматах отличных от html выбрасывало 500, так как падало на поиске шаблона
<img width="1278" alt="Снимок экрана 2025-02-21 в 17 38 55" src="https://github.com/user-attachments/assets/3efac81a-84ea-42c3-8df3-2288ddebadda" />
Вот пример ошибки из сентри
https://hexlet-sq.sentry.io/issues/6261061341/?alert_rule_id=10688616&alert_type=issue&environment=production&notification_uuid=029ebe14-cbec-413d-a7cc-a095ba0876b4&project=6298540&referrer=slack
Также попутно установил доступные локали в приложении (немного не по теме ПРа). Так как есть код который опирается на эту логику, а available_locales содержал список со всевозможными локалями