### PR TITLE
Add search by email field to users management page

### DIFF
--- a/app/javascript/locales.json
+++ b/app/javascript/locales.json
@@ -846,7 +846,8 @@
             },
             "index": {
               "finished_lessons": "Finished Lessons",
-              "header": "Users"
+              "header": "Users",
+              "search_by_email": "Search by email"
             }
           }
         },
@@ -2750,7 +2751,8 @@
             },
             "index": {
               "finished_lessons": "Завершенные уроки",
-              "header": "Пользователи"
+              "header": "Пользователи",
+              "search_by_email": "Поиск по email"
             }
           }
         },

--- a/app/javascript/pages/web/admin/management/users/index.tsx
+++ b/app/javascript/pages/web/admin/management/users/index.tsx
@@ -10,6 +10,7 @@ import type { User, Grid } from '@/types/serializers';
 import { Menu } from './shared/menu';
 import useDataTableProps from '@/hooks/useDataTableProps';
 import { Edit } from 'lucide-react';
+import { XForm, XInput } from "@/components/forms";
 import dayjs from 'dayjs';
 
 type Props = PropsWithChildren & {
@@ -37,7 +38,15 @@ export default function Index({ grid, users }: Props) {
           { accessor: 'admin', title: 'Admin?' },
           { accessor: 'assistant_messages_count', title: 'Messages' },
           { accessor: 'name', sortable: true },
-          { accessor: 'email', sortable: true },
+          {
+            accessor: 'email',
+            sortable: true,
+            filter: (
+              <XForm method="get" to={Routes.admin_management_users_path()}>
+                <XInput field="fields[email_cont]" label={t('admin.management.users.index.search_by_email')} />
+              </XForm>
+            )
+          },
           {
             accessor: 'created_at',
             sortable: true,

--- a/config/locales/en.views.yml
+++ b/config/locales/en.views.yml
@@ -70,6 +70,7 @@ en:
             header: Edit User
           index:
             header: Users
+            search_by_email: Search by email
             finished_lessons: Finished Lessons
     home:
       hero:

--- a/config/locales/ru.views.yml
+++ b/config/locales/ru.views.yml
@@ -172,6 +172,7 @@ ru:
             header: Редактирование пользователя
           index:
             finished_lessons: Завершенные уроки
+            search_by_email: Поиск по email
             header: Пользователи
           filter:
             from: Начал прохождение с


### PR DESCRIPTION
Добавила поле поиска по email на странице управления пользователями для фильтрации.

<img src="https://github.com/user-attachments/assets/228bc8ab-1bd0-4a87-a3ce-96443f02fcb5" width="599">

Небольшое пояснение: во время интервью до pull request-а не дошли, но я реешила доделать задание и отправила PR, так как Кирилл говорил задача реальная.
