### PR TITLE
fix build: using await on top-level

### DIFF
--- a/app/javascript/components/MarkdownViewer.tsx
+++ b/app/javascript/components/MarkdownViewer.tsx
@@ -5,7 +5,8 @@ import rehypeExternalLinks from "rehype-external-links";
 import rehypeRaw from "rehype-raw";
 import type { PluggableList } from "unified";
 import { Box, TypographyStylesProvider, useMantineColorScheme } from "@mantine/core";
-import highlighter from "@/lib/shiki";
+import getHighlighter from "@/lib/shiki";
+import { useEffect, useState } from "react";
 
 type MarkdownViewerProps = {
   children: string;
@@ -17,21 +18,32 @@ export default function MarkdownViewer({
   allowHtml = false,
 }: MarkdownViewerProps) {
   // const { colorScheme } = useMantineColorScheme();
+  const [rehypePlugins, setRehypePlugins] = useState<PluggableList>([]);
 
-  const rehypePlugins: PluggableList = [
-    [rehypeShikiFromHighlighter, highlighter, {
-      themes: { light: "github-light", dark: "github-dark" },
-      theme: 'github-light',
-    }],
-    [rehypeExternalLinks, {
-      target: "_blank",
-      rel: ["noopener", "noreferrer"],
-    }],
-  ];
+  useEffect(() => {
+    const loadPlugins = async () => {
+      const highlighter = await getHighlighter();
 
-  if (allowHtml) {
-    rehypePlugins.push(rehypeRaw)
-  }
+      const rehypePlugins: PluggableList = [
+        [rehypeShikiFromHighlighter, highlighter, {
+          themes: { light: "github-light", dark: "github-dark" },
+          theme: 'github-light',
+        }],
+        [rehypeExternalLinks, {
+          target: "_blank",
+          rel: ["noopener", "noreferrer"],
+        }],
+      ];
+
+      if (allowHtml) {
+        rehypePlugins.push(rehypeRaw)
+      }
+
+      setRehypePlugins(rehypePlugins);
+    }
+
+    loadPlugins();
+  }, [allowHtml]);
 
   return (
     <TypographyStylesProvider>

--- a/app/javascript/components/Root.tsx
+++ b/app/javascript/components/Root.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from "react-i18next";
 import { Text, Center, MantineProvider, Stack, Title, type MantineProviderProps, Container } from '@mantine/core';
 import { CodeHighlightAdapterProvider, createShikiAdapter } from '@mantine/code-highlight';
 import { ModalsProvider } from "@mantine/modals";
-import highlighter from "@/lib/shiki";
+import getHighlighter from "@/lib/shiki";
 
-const shikiAdapter = createShikiAdapter(async () => highlighter);
+const shikiAdapter = createShikiAdapter(getHighlighter);
 
 function FallbackComponent() {
   const { t: tLayouts } = useTranslation("layouts");

--- a/app/javascript/lib/shiki.ts
+++ b/app/javascript/lib/shiki.ts
@@ -1,47 +1,48 @@
 import { createHighlighterCore } from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
-const getHighlighter = async () => {
-  const highlighter = await createHighlighterCore({
-    langs: [
-      import('@shikijs/langs/tsx'),
-      import('@shikijs/langs/swift'),
-      import('@shikijs/langs/rust'),
-      import('@shikijs/langs/scss'),
-      import('@shikijs/langs/css'),
-      import('@shikijs/langs/html'),
-      import('@shikijs/langs/bash'),
-      import('@shikijs/langs/json'),
-      import('@shikijs/langs/elixir'),
-      import('@shikijs/langs/clojure'),
-      import('@shikijs/langs/racket'),
-      import('@shikijs/langs/1c'),
-      // import('@shikijs/langs/c'),
-      // import('@shikijs/langs/cpp'),
-      import('@shikijs/langs/haskell'),
-      import('@shikijs/langs/js'),
-      import('@shikijs/langs/ts'),
-      import('@shikijs/langs/jsx'),
-      import('@shikijs/langs/php'),
-      import('@shikijs/langs/java'),
-      import('@shikijs/langs/ruby'),
-      import('@shikijs/langs/csharp'),
-      import('@shikijs/langs/go'),
-      import('@shikijs/langs/python'),
-      import('@shikijs/langs/scheme'),
-      import('@shikijs/langs/perl'),
-    ],
-    themes: [
-      import('@shikijs/themes/github-dark'),
-      import('@shikijs/themes/github-light'),
-    ],
-    engine: createJavaScriptRegexEngine(),
-  })
-
+const highlighterPromise = createHighlighterCore({
+  langs: [
+    import('@shikijs/langs/tsx'),
+    import('@shikijs/langs/swift'),
+    import('@shikijs/langs/rust'),
+    import('@shikijs/langs/scss'),
+    import('@shikijs/langs/css'),
+    import('@shikijs/langs/html'),
+    import('@shikijs/langs/bash'),
+    import('@shikijs/langs/json'),
+    import('@shikijs/langs/elixir'),
+    import('@shikijs/langs/clojure'),
+    import('@shikijs/langs/racket'),
+    import('@shikijs/langs/1c'),
+    // import('@shikijs/langs/c'),
+    // import('@shikijs/langs/cpp'),
+    import('@shikijs/langs/haskell'),
+    import('@shikijs/langs/js'),
+    import('@shikijs/langs/ts'),
+    import('@shikijs/langs/jsx'),
+    import('@shikijs/langs/php'),
+    import('@shikijs/langs/java'),
+    import('@shikijs/langs/ruby'),
+    import('@shikijs/langs/csharp'),
+    import('@shikijs/langs/go'),
+    import('@shikijs/langs/python'),
+    import('@shikijs/langs/scheme'),
+    import('@shikijs/langs/perl'),
+  ],
+  themes: [
+    import('@shikijs/themes/github-dark'),
+    import('@shikijs/themes/github-light'),
+  ],
+  engine: createJavaScriptRegexEngine(),
+}).then((highlighter) => {
   highlighter.getTheme('github-light').bg = 'var(--mantine-color-gray-0)';
   highlighter.getTheme('github-dark').bg = 'var(--mantine-color-gray-7)';
 
   return highlighter;
-};
+});
 
-export default getHighlighter;
+export default async () => {
+  const highlighter = await highlighterPromise
+  return highlighter;
+}

--- a/app/javascript/lib/shiki.ts
+++ b/app/javascript/lib/shiki.ts
@@ -1,43 +1,47 @@
 import { createHighlighterCore } from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
-const highlighter = await createHighlighterCore({
-  langs: [
-    import('@shikijs/langs/tsx'),
-    import('@shikijs/langs/swift'),
-    import('@shikijs/langs/rust'),
-    import('@shikijs/langs/scss'),
-    import('@shikijs/langs/css'),
-    import('@shikijs/langs/html'),
-    import('@shikijs/langs/bash'),
-    import('@shikijs/langs/json'),
-    import('@shikijs/langs/elixir'),
-    import('@shikijs/langs/clojure'),
-    import('@shikijs/langs/racket'),
-    import('@shikijs/langs/1c'),
-    // import('@shikijs/langs/c'),
-    // import('@shikijs/langs/cpp'),
-    import('@shikijs/langs/haskell'),
-    import('@shikijs/langs/js'),
-    import('@shikijs/langs/ts'),
-    import('@shikijs/langs/jsx'),
-    import('@shikijs/langs/php'),
-    import('@shikijs/langs/java'),
-    import('@shikijs/langs/ruby'),
-    import('@shikijs/langs/csharp'),
-    import('@shikijs/langs/go'),
-    import('@shikijs/langs/python'),
-    import('@shikijs/langs/scheme'),
-    import('@shikijs/langs/perl'),
-  ],
-  themes: [
-    import('@shikijs/themes/github-dark'),
-    import('@shikijs/themes/github-light'),
-  ],
-  engine: createJavaScriptRegexEngine(),
-})
+const getHighlighter = async () => {
+  const highlighter = await createHighlighterCore({
+    langs: [
+      import('@shikijs/langs/tsx'),
+      import('@shikijs/langs/swift'),
+      import('@shikijs/langs/rust'),
+      import('@shikijs/langs/scss'),
+      import('@shikijs/langs/css'),
+      import('@shikijs/langs/html'),
+      import('@shikijs/langs/bash'),
+      import('@shikijs/langs/json'),
+      import('@shikijs/langs/elixir'),
+      import('@shikijs/langs/clojure'),
+      import('@shikijs/langs/racket'),
+      import('@shikijs/langs/1c'),
+      // import('@shikijs/langs/c'),
+      // import('@shikijs/langs/cpp'),
+      import('@shikijs/langs/haskell'),
+      import('@shikijs/langs/js'),
+      import('@shikijs/langs/ts'),
+      import('@shikijs/langs/jsx'),
+      import('@shikijs/langs/php'),
+      import('@shikijs/langs/java'),
+      import('@shikijs/langs/ruby'),
+      import('@shikijs/langs/csharp'),
+      import('@shikijs/langs/go'),
+      import('@shikijs/langs/python'),
+      import('@shikijs/langs/scheme'),
+      import('@shikijs/langs/perl'),
+    ],
+    themes: [
+      import('@shikijs/themes/github-dark'),
+      import('@shikijs/themes/github-light'),
+    ],
+    engine: createJavaScriptRegexEngine(),
+  })
 
-highlighter.getTheme('github-light').bg = 'var(--mantine-color-gray-0)';
-highlighter.getTheme('github-dark').bg = 'var(--mantine-color-gray-7)';
+  highlighter.getTheme('github-light').bg = 'var(--mantine-color-gray-0)';
+  highlighter.getTheme('github-dark').bg = 'var(--mantine-color-gray-7)';
 
-export default highlighter
+  return highlighter;
+};
+
+export default getHighlighter;


### PR DESCRIPTION
фикс ошибки при сборке
https://github.com/hexlet-basics/hexlet-basics/actions/runs/16074084639/job/45365068370
```
[vite:esbuild-transpile] Transform failed with 1 error:
assets/inertia-!~{002}~.js:38513:20: ERROR: Top-level await is not available in the configured target environment ("chrome64", "edge79", "es2020", "firefox67", "safari12" + 2 overrides)
file: assets/inertia-!~{002}~.js:38513:20

Top-level await is not available in the configured target environment ("chrome64", "edge79", "es2020", "firefox67", "safari12" + 2 overrides)
38511|  }
38512|  
38513|  const highlighter = await createHighlighterCore({
   |                      ^
38514|    langs: [
38515|      __vitePreload(() => import('./tsx-!~{027}~.js'),true              ?__VITE_PRELOAD__:void 0),
```