### PR TITLE
chore(readme): fix github action status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![github action status](https://github.com/hexlet-basics/hexlet-basics/workflows/build/badge.svg?event=push)](https://github.com/hexlet-basics/hexlet-basics/actions)
+[![github action status](https://github.com/hexlet-basics/hexlet-basics/actions/workflows/build.yml/badge.svg?event=push)](https://github.com/hexlet-basics/hexlet-basics/actions/workflows/build.yml)
 
 # hexlet-basics
 


### PR DESCRIPTION
Гитхаб больше не позволяет ссылаться на всю папку, нужно выбрать yml на который будем ссылаться либо использовать два статуса:

```
[![build](https://github.com/hexlet-basics/hexlet-basics/actions/workflows/build.yml/badge.svg?event=push)](https://github.com/hexlet-basics/hexlet-basics/actions/workflows/build.yml)
[![release](https://github.com/hexlet-basics/hexlet-basics/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/hexlet-basics/hexlet-basics/actions/workflows/release.yml)
```

https://docs.github.com/en/actions/how-tos/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge