### PR TITLE
remove senseless query of user with null id

### DIFF
--- a/app/controllers/concerns/auth_concern.rb
+++ b/app/controllers/concerns/auth_concern.rb
@@ -25,7 +25,7 @@ module AuthConcern
   end
 
   def current_user
-    @current_user ||= User.active.find_by(id: session[:user_id]) || Guest.new
+    @current_user ||= (session[:user_id].present? ? User.active.find_by(id: session[:user_id]) : nil) || Guest.new
   end
 
   def authenticate_user!


### PR DESCRIPTION
Если пользователь не был авторизован, то в БД выполнялся запрос вида `SELECT "users".* FROM "users" WHERE "users"."state" = 'active' AND "users"."id" IS NULL LIMIT 1`, что является бессмысленным, так как пользователя с таким id не может быть.

Так как `current_user` используется во многих частях приложения, то данное изменение оптимизирует работу приложения _в целом_  для неавторизованного пользователя.