### PR TITLE
remove confusing password error message

### DIFF
--- a/app/forms/sign_in_form.rb
+++ b/app/forms/sign_in_form.rb
@@ -10,15 +10,15 @@ class SignInForm
   validate :user_exists, :user_can_sign_in
 
   def user_can_sign_in
-    errors.add(:password, :cannot_sign_in) if password.present? && !user&.valid_password?(password)
+    errors.add(:password, :cannot_sign_in) if password.present? && user && !user.valid_password?(password)
   end
 
   def user_exists
-    errors.add(:email, :user_does_not_exist_html) if email.present? && !user
+    errors.add(:email, :user_does_not_exist_html) unless user
   end
 
   def user
-    @user ||= User.active.find_by(email: email)
+    @user ||= User.active.find_by(email: email) if email.present?
   end
 
   def email=(value)


### PR DESCRIPTION
Убран вывод ошибки о неверном пароле, когда пользователь ввёл некорректный email, так как в этом случае невозможно достоверно проверить корректность пароля.

Пользователь мог ввести верный пароль, но допустить опечатку при вводе email. В этом случае вывод ошибки мог ввести пользователя в заблуждение и вынудить совершить лишнее действие - переписать пароль.

---

- До
<img width="558" height="412" alt="wrong_mail+correct_pass-before" src="https://github.com/user-attachments/assets/520a3019-7c33-4f18-8657-a9f75b72dbec" />
<img width="556" height="408" alt="empty_mail+correct_pass-before" src="https://github.com/user-attachments/assets/57b1f9d7-5492-47c4-9019-831691a4259d" />

---

- После
<img width="558" height="387" alt="wrong_mail+correct_pass-after" src="https://github.com/user-attachments/assets/6c08b9bc-8f00-41e8-ab68-7a87bc739c50" />
<img width="558" height="387" alt="empty_mail+correct_pass-after" src="https://github.com/user-attachments/assets/49c0ee71-c79d-45b7-90ff-d6be6196d880" />
