### PR TITLE
ID-633-update-footer-block-link-to-the-hexlet

### DIFF
--- a/app/javascript/pages/layouts/blocks/FooterBlock.tsx
+++ b/app/javascript/pages/layouts/blocks/FooterBlock.tsx
@@ -72,7 +72,7 @@ export default function FooterBlock() {
                     support@hexlet.io
                   </Anchor>
                   <Stack mt="sm" gap={0}>
-                    <AppAnchor href={Routes.root_path()} mb="xs">
+                    <AppAnchor href="https://ru.hexlet.io" external mb="xs">
                       ООО «Хекслет Рус»
                     </AppAnchor>
                     <Text>


### PR DESCRIPTION
#633 fix: redirect to https://ru.hexlet.io/