### PR TITLE
feed link for lang lessons

### DIFF
--- a/app/lib/yandex_search_feed_builder.rb
+++ b/app/lib/yandex_search_feed_builder.rb
@@ -27,7 +27,7 @@ module YandexSearchFeedBuilder
 
           xml.offers do
             landingPages.each do |lp|
-              module_infos = lp.language.current_module_infos.with_locale
+              module_infos = lp.language.current_module_infos.with_locale.includes(version: { lesson_versions: :lesson })
 
               if module_infos.size < 3
                 next
@@ -68,6 +68,10 @@ module YandexSearchFeedBuilder
                     xml.cdata <<-CDATA
                     #{mi.description}
                     CDATA
+                  end
+
+                  mi.version.lesson_versions.sort_by(&:natural_order) .each do |lv|
+                    xml.param(name: "Ссылка на контент курса") { xml.text urls.language_lesson_url(lp.language.slug, lv.lesson.slug, suffix: :ru) }
                   end
                 end
               end


### PR DESCRIPTION
Для органической выдачи яндекса добавлены поля “Ссылка на контент курса” равное всем урокам в модуле
<img width="933" height="545" alt="Screenshot 2025-09-17 at 19 32 09" src="https://github.com/user-attachments/assets/367fc967-eb27-45c3-b0bf-08b16c0b4e2b" />
