### PR TITLE
Make current lesson label bold in navigation

### DIFF
--- a/app/javascript/pages/web/languages/lessons/show/index.tsx
+++ b/app/javascript/pages/web/languages/lessons/show/index.tsx
@@ -399,23 +399,26 @@ function AssistantTabContent({ focusesCount }: { focusesCount: number }) {
 }
 
 function NavigationTabContent() {
-  const { lessons, landingPage } = usePage<LessonSharedProps>().props;
-
+  const { lesson, lessons, landingPage } = usePage<LessonSharedProps>().props;
   return (
     <Box p="lg">
       <List type="ordered">
-        {lessons.map((l) => (
-          <List.Item key={l.id}>
-            <AppAnchor
-              href={Routes.language_lesson_path(
-                landingPage.language.slug!,
-                l.slug!,
-              )}
-            >
-              {l.name}
-            </AppAnchor>
-          </List.Item>
-        ))}
+        {lessons.map((l) => {
+          const lessonItemFontWeight = l.id === lesson.id ? 'bold' : 'normal';
+          return (
+            <List.Item key={l.id}>
+              <AppAnchor
+                href={Routes.language_lesson_path(
+                  landingPage.language.slug!,
+                  l.slug!,
+                )}
+                fw={lessonItemFontWeight}
+              >
+                {l.name}
+              </AppAnchor>
+            </List.Item>
+          );
+        })}
       </List>
     </Box>
   );


### PR DESCRIPTION
Предлагаю выделить текущий урок в табе навигации, так, как будто бы проще ориентироваться
<img width="710" height="332" alt="Снимок экрана 2025-10-01 в 16 16 00" src="https://github.com/user-attachments/assets/678b5349-ee9c-46a1-9352-4a4922027464" />
